### PR TITLE
FixBugs:修复一个goodsId与shopId混淆问题

### DIFF
--- a/wxshop-main/src/main/java/com/hcsp/wxshop/service/GoodsService.java
+++ b/wxshop-main/src/main/java/com/hcsp/wxshop/service/GoodsService.java
@@ -72,7 +72,8 @@ public class GoodsService {
     }
 
     public Goods deleteGoodsById(Long goodsId) {
-        Shop shop = shopMapper.selectByPrimaryKey(goodsId);
+        Goods goodsInfo = goodsMapper.selectByPrimaryKey(goodsId);
+        Shop shop = shopMapper.selectByPrimaryKey(goodsInfo.getShopId());
 
         if (shop == null || Objects.equals(shop.getOwnerUserId(), UserContext.getCurrentUser().getId())) {
             Goods goods = goodsMapper.selectByPrimaryKey(goodsId);


### PR DESCRIPTION
此问题带来了删除商品时错误的将goodsId与shopId绑定，
使删除时只能两个Id都存在的情况下才能删除